### PR TITLE
 Update Issue Templates for Bug Fixes, Feature Requests, etc.

### DIFF
--- a/.github/ISSUE_TEMPLATE/.config.yml
+++ b/.github/ISSUE_TEMPLATE/.config.yml
@@ -1,0 +1,7 @@
+contact_links:
+    - name: 📃 Documentation Issue
+      url: https://github.com/c-code-x/codex-website/issues/new
+      about: This issue tracker is not for documentation issues. Please file documentation issues here.
+    - name: 🤔 Questions and Help
+      url: https://github.com/orgs/c-code-x/discussions
+      about: This issue tracker is not for support questions. Please refer to the Codex community's help and discussion forums.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,41 @@
+name: 🐛 Bug Report
+description: File a bug report here
+title: "[Bug]: "
+labels: ["bug"]
+assignees: ["Jaideep-C"]
+body:
+    - type: markdown
+      attributes:
+          value: |
+              Thanks for taking the time to fill out this bug report! 🤗
+              Please make sure this topic hasn't been already submitted by someone by looking through other open/closed issues. 😃
+
+    - type: textarea
+      id: bug-description
+      attributes:
+          label: Description of the bug
+          description: Give us a brief description of what happened and what should have happened.
+          placeholder: |
+              Tell us what you see!
+      validations:
+          required: true
+
+    - type: textarea
+      id: steps-to-reproduce
+      attributes:
+          label: Steps To Reproduce
+          description: Steps to reproduce the behavior.
+          placeholder: |
+              1. Go to '...'
+              2. Click on '...'
+              3. Scroll down to '...'
+              4. See error
+      validations:
+          required: true
+
+    - type: textarea
+      id: additional-information
+      attributes:
+          label: Additional Information
+          description: |
+              Provide any additional information such as logs, screenshots, likes, scenarios in which the bug occurs so that it facilitates resolving the issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,40 @@
+name: ✨ Feature Request
+description: Suggest an idea for this project
+title: "[Feature]: "
+labels: ["enhancement"]
+assignees: ["Jaideep-C"]
+body:
+    - type: markdown
+      attributes:
+          value: |
+              Thanks for taking the time to fill out this feature request! 🤗
+              Please make sure this feature request hasn't been already submitted by someone by looking through other open/closed issues. 😃
+
+    - type: dropdown
+      attributes:
+          multiple: false
+          label: Type of Feature
+          description: Select the type of feature request.
+          options:
+              - "✨ New Feature"
+              - "📝 Documentation"
+              - "🎨 Style and UI"
+              - "🔨 Code Refactor"
+              - "⚡ Performance Improvements"
+              - "✅ New Test"
+      validations:
+          required: true
+
+    - type: textarea
+      id: description
+      attributes:
+          label: Description
+          description: Give us a brief description of the feature or enhancement you would like
+      validations:
+          required: true
+
+    - type: textarea
+      id: additional-information
+      attributes:
+          label: Additional Information
+          description: Give us some additional information on the feature request like proposed solutions, links, screenshots, etc.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,63 @@
+## Type of Change
+
+<!--
+Please delete options that are not relevant.
+ -->
+
+- [ ] ✨ New Feature
+- [ ] 🐛 Bug Fix
+- [ ] 💥 Breaking Change
+- [ ] 📝 Documentation Update
+- [ ] 🎨 Style and UI
+- [ ] 🔨 Code Refactor
+- [ ] ⚡ Performance Improvements
+- [ ] ✅ New Test
+- [ ] 👷 Build and CI
+
+## Description
+
+<!--
+Please include a summary of the changes and the link to the ticket (jira/canban board etc). Please also include relevant motivation and context. List any dependencies that are required for this change.
+ -->
+
+## Related Tickets & Documents
+
+<!--
+Using keywords such as Closes #10, or Fixes #5 links to the issue and closes it once the pull request is merged.
+
+For multiple issues:
+Resolves #10, resolves #123, resolves octo-org/octo-repo#100
+
+For more information:
+ -->
+
+- Fixes # (issue)
+
+## How Has This Been Tested?
+
+<!--
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
+ -->
+
+- [ ] Screenshot A
+- [ ] Screenshot B
+
+## Added or Updated Tests?
+
+<!--
+Please delete options that are not relevant.
+ -->
+
+- [ ] 👍 Yes
+- [ ] 🙅 No, and this is why: please replace this line with details on why tests have not been included
+- [ ] 🙋 I need help with writing tests
+
+## Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes


### PR DESCRIPTION
I have created three new issue templates using GitHub's built-in templates feature. The templates are designed to cover common types of issues, such as bug reports, feature requests, and general feedback. By using these templates, contributors will be able to provide more detailed and structured issue reports, which will help us to resolve issues more efficiently.

The templates are as follows:
- Two templates for issues:
    - Bug reports
    - Feature requests
- One template for pull requests

Each template provides detailed instructions for opening issues and pull requests, including examples of well-structured issue reports and pull requests. I have also updated the contribution guidelines to clarify the process for submitting issues and pull requests, specify the expected format for pull requests, define code formatting and quality standards, and outline commit message format and conventions.

This PR resolves issue #70.

Please review this PR and let me know if you have any feedback or suggestions. Thank you!